### PR TITLE
Use window.innerWidth instead of body.clientWidth

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -332,7 +332,7 @@
       },
 
       onWindowResize () {
-        this.window.width = document.body.clientWidth
+        this.window.width = window.innerWidth
         this.window.height = window.innerHeight
       },
 


### PR DESCRIPTION
Fixes pivot-x for cases where you have body smaller than document,
for example:

```html
<!DOCTYPE html>
<html>
<head>
  <style>
    html {
      background-color: white;
    }
    body {
      width: 80%;
      background-color: lightgreen;
    }
  </style>
</head>
<body>
  <script>
      document.body.innerHTML += `<pre>
        window.innerWidth is ${window.innerWidth}<br>
        document.body.clientWidth is ${document.body.clientWidth}<br>
        window.innerWidth == document.body.clientWidth: ${window.innerWidth == document.body.clientWidth}`
    </script>
  </body>
</html>
```

Fixes issue #84