### PR TITLE
Remove Vue runtime dependency

### DIFF
--- a/build/webpack.base.config.js
+++ b/build/webpack.base.config.js
@@ -25,14 +25,6 @@ module.exports = {
       }
     ]
   },
-  externals: {
-    vue: 'vue'
-  },
-  resolve: {
-    alias: {
-      'vue$': 'vue/dist/vue.esm.js'
-    }
-  },
   devtool: '#source-map',
   plugins: [
     new UglifyJSPlugin({

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -28,7 +28,6 @@
   </transition>
 </template>
 <script>
-  import Vue         from 'vue'
   import Modal       from './index'
   import Resizer     from './Resizer.vue'
   import { inRange } from './util'
@@ -348,7 +347,7 @@
           ref: this.$refs.modal
         }
 
-        return Vue.util.extend(data, params || {})
+        return Object.assign(data, params || {})
       },
       /**
        * Event handler which is triggered on modal resize


### PR DESCRIPTION
This allow the bundle to be used in jsfiddle, plnkr, jsbin, etc.,
as the bundle does not depend on Vue.

The problem lies on second line of bundle

```js
"object" == typeof exports ? exports["vue-js-modal"] = factory(require("vue")) : root["vue-js-modal"] = factory(root.vue)
```

where `factory` tries to find `root.vue`, but the official Vue bundle exports
as `root.Vue`.

Removing the runtime dependency solves this.

`Object.assign` is available in all browsers but IE:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign