### PR TITLE
Use type="button" for buttons on dialog

### DIFF
--- a/src/Dialog.vue
+++ b/src/Dialog.vue
@@ -27,6 +27,7 @@
       <button 
         v-for="(button, i) in buttons"
         :class="button.class || 'vue-dialog-button'"
+        type="button"
         :style="buttonStyle"
         :key="i"
         v-html="button.title"


### PR DESCRIPTION
Without `type="button"` on the buttons on dialog, they will act as submit buttons if the dialog is located inside of a form. If that's desired behavior it can always be easily simulated with `handler`, but it's probably an undesirable behavior in most situations, hence this PR.