### PR TITLE
Change Dialog component name to VueJsDialog to prevent warning message

### DIFF
--- a/src/Dialog.vue
+++ b/src/Dialog.vue
@@ -40,7 +40,7 @@
 </template>
 <script>
 export default {
-  name: 'Dialog',
+  name: 'VueJsDialog',
   props: {
     width: {
       type: [Number, String],


### PR DESCRIPTION
This fixes #149 by changing Dialog component name to VueJsDialog