### PR TITLE
Added disable page scroll class to html element

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -460,10 +460,12 @@ export default {
         }
 
         if (scrollable) {
+          document.getElementsByTagName('html')[0].classList.add('v--modal-block-scroll')
           document.body.classList.add('v--modal-block-scroll')
         }
       } else {
         if (scrollable) {
+          document.getElementsByTagName('html')[0].classList.remove('v--modal-block-scroll')
           document.body.classList.remove('v--modal-block-scroll')
         }
       }


### PR DESCRIPTION
In some scenarios adding  "overflow:hidden" to the body tag doesn't prevent page scrolling. In those cases, you have to add the property to the html tag as well.

From the [CSS 2.2 spec for the overflow property](https://www.w3.org/TR/CSS22/visufx.html#propdef-overflow)

> UAs must apply the 'overflow' property set on the root element to the viewport. When the root element is an HTML "HTML" element or an XHTML "html" element, and that element has an HTML "BODY" element or an XHTML "body" element as a child, user agents must instead apply the 'overflow' property from the first such child element to the viewport, if the value on the root element is 'visible'.