### PR TITLE
removed position attribute on block-scroll class

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -635,7 +635,6 @@ export default {
 </script>
 <style>
 .v--modal-block-scroll {
-  position: absolute;
   overflow: hidden;
   width: 100vw;
 }


### PR DESCRIPTION
Removed ```position: absolute;``` from the  v--modal-block-scroll class. As caused conflicts with elements contained in the page body using  ```position: absolute;``` and is not required to prevent page scrolling.