### PR TITLE
Disable scroll bar without removing the space it occupies

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -468,11 +468,24 @@ export default {
         }
 
         if (scrollable) {
+          // Store original body padding-right
+          document.body.dataset.vModalBlockScrollRightPadding = document.body.style.paddingRight;
+
+          // Apply scrollBarWidth as padding
+          const scrollBarWidth = window.innerWidth - $('body').scrollWidth;
+          document.body.style.paddingRight = `${scrollBarWidth}px`;
+
+          // Apply scroll class
           document.getElementsByTagName('html')[0].classList.add('v--modal-block-scroll')
           document.body.classList.add('v--modal-block-scroll')
         }
       } else {
         if (scrollable) {
+          // Restore original padding-right on body
+          document.body.style.paddingRight = document.body.dataset.vModalBlockScrollRightPadding || '';
+          delete document.body.dataset.vModalBlockScrollRightPadding;
+
+          // Remove existing scroll class
           document.getElementsByTagName('html')[0].classList.remove('v--modal-block-scroll')
           document.body.classList.remove('v--modal-block-scroll')
         }


### PR DESCRIPTION
### Description
Disable scroll bar without removing the space it occupies.

Mechanism:
- This is achieved by adding extra padding to the body element to accomondate the missing scrollbar.

Note:
- This will also work if there is no scroll bar available (i.e. on touch devices)
- This should also work if the body previously contain padding-right (it will be restored upon closing the modal)
- This implementation attempt to mimic how bootstrap implement its modal https://github.com/twbs/bootstrap/blob/bedc96e48bebb7a1124a97833794a8047a1e3b95/js/src/modal.js#L414

### Motivation
So that the webpage will not jump horizontally when opening and closing a scrollable modal

### Screenshot
#### Before modal is opened
![image](https://user-images.githubusercontent.com/8733840/37694429-1a74b872-2d02-11e8-9f14-7f84f62dc6ac.png)

#### After modal is opened
![image](https://user-images.githubusercontent.com/8733840/37694431-1e754c70-2d02-11e8-954c-188f374b4b09.png)


