### PR TITLE
Fixing auto error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,12 +350,12 @@ And then forbits closing it for the next 5000 ms
 
 From `v1.2.6` height can be set to "auto". If you want to be able to scroll modal in case it's height exceeds window height - you can set flag `scrollable="true"`.
 
-p.s. `scrollable` will only work with `height="auto"`.
+p.s. `scrollable` will only work with `height="'auto'"`.
 
 Example:
 
 ```vue
-<modal name="foo" height="auto" :scrollable="true">...</modal>
+<modal name="foo" height="'auto'" :scrollable="true">...</modal>
 ```
 
 Auto height:


### PR DESCRIPTION
There are missing quotations marks in two of the examples specifically focused on the `auto` param. Without single quotes around the auto, Vue was parsing these as variables and throwing an error (i.e. 'auto is referenced but not defined'). This pull request simply adds the single quotes in the example.

Small thing, but wanted to fix it!