### PR TITLE
Performance Improvements: Use `transform: translate3d`

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ There is also a ssr build with css file extracted. Take a look in /dist folder.
 | draggable | false | [Boolean, String]| false       | If true, modal box will be draggable. |
 | scrollable | false | Boolean         | false       | If `height` property is `auto` and the modal height exceeds window height - you will be able to scroll modal |
 | reset     | false | Boolean          | false       | Resets position and size before showing modal |
+| absolutePositioning | false | Boolean | false      | Force an absolute positioning using left and top instead of CSS `transform` |
+| force3d   | false | Boolean          | true        | If set to `false`, it will position the modal using `translate` instead of `translate3d` |
 | clickToClose | false | Boolean       | true        | If set to `false`, it will not be possible to close modal by clicking on the background |
 | transition| false | String           |             | Transition name |
 | classes   | false | [String, Array]  | 'v--modal'| Classes that will be applied to the actual modal box, if not specified, the default 'vue--modal' class will be applied |

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -66,6 +66,14 @@ export default {
       type: Boolean,
       default: false
     },
+    absolutePositioning: {
+      type: Boolean,
+      default: false
+    },
+    force3d: {
+      type: Boolean,
+      default: true
+    },
     transition: {
       type: String
     },
@@ -359,12 +367,20 @@ export default {
      * CSS styles for position and size of the modal
      */
     modalStyle () {
-      return {
+      let style = {
         top: this.position.top + 'px',
-        left: this.position.left + 'px',
-        width: this.trueModalWidth + 'px',
-        height: this.isAutoHeight ? 'auto' : this.trueModalHeight + 'px'
+        left: this.position.left + 'px'
       }
+      // absolutePositioning parameter is here for legacy purposes
+      if (this.absolutePositioning) {
+        style.top = this.position.top + 'px';
+        style.left = this.position.left + 'px';
+      } else if (this.force3d) {
+        style.transform = 'translate3d(' + Math.round(this.position.left) + 'px, ' + Math.round(this.position.top) + 'px, 0px)';
+      } else {
+        style.transform = 'translate(' + Math.round(this.position.left) + 'px, ' + Math.round(this.position.top) + 'px)';
+      }
+      return style;
     }
   },
   methods: {

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -368,9 +368,9 @@ export default {
      */
     modalStyle () {
       let style = {
-        top: this.position.top + 'px',
-        left: this.position.left + 'px'
-      }
+        width: this.trueModalWidth + 'px',
+        height: this.isAutoHeight ? 'auto' : this.trueModalHeight + 'px'
+      };
       // absolutePositioning parameter is here for legacy purposes
       if (this.absolutePositioning) {
         style.top = this.position.top + 'px';


### PR DESCRIPTION
Performances improvements through the use of CSS' `transform: translate3d` instead of `left/top` absolute positioning.

Translate3d offers huge performance increases through the use of hardware acceleration when available.

New parameters:

- `force3d` toggles the use of `translate` instead of `translate3d`.
- `absolutePositioning` uses the legacy `left/top` absolute positioning for those who do not want translate positioning**.

**: Using CSS's `transform` attribute will create a new [stacking context](https://tiffanybbrown.com/2015/09/css-stacking-contexts-wtf/index.html) and therefore - in some rare situations - it might not be something you want to do.
 