### PR TITLE
Events missing in show() type definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,7 +9,7 @@ export declare interface VueJSModalOptions {
 }
 
 declare interface VModal {
-  show(modal: string | typeof Vue | ComponentOptions<Vue>, paramsOrProps?: object, params?: object): void;
+  show(modal: string | typeof Vue | ComponentOptions<Vue>, paramsOrProps?: object, params?: object, events?: object): void;
   hide(name: string, params?: object): void;
   toggle(name: string, params?: object): void;
 }


### PR DESCRIPTION
Typings don't allow adding fourth parameter (events) when calling show().