### PR TITLE
Fixes jump-to-top when modal is open and scrollable optionis true

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -450,12 +450,10 @@ export default {
         }
 
         if (scrollable) {
-          document.getElementsByTagName('html')[0].classList.add('v--modal-block-scroll')
           document.body.classList.add('v--modal-block-scroll')
         }
       } else {
         if (scrollable) {
-          document.getElementsByTagName('html')[0].classList.remove('v--modal-block-scroll')
           document.body.classList.remove('v--modal-block-scroll')
         }
       }


### PR DESCRIPTION
If you add the class `v--modal-block-scroll` only to the `body` element and not to the `html` the content will not jump to top if you open the modal.