### PR TITLE
Fix blocked scroll.

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -262,6 +262,12 @@ export default {
     if (this.clickToClose) {
       window.removeEventListener('keyup', this.onEscapeKeyUp)
     }
+    /**
+     * Removes blocked scroll
+     */
+    if (this.scrollable) {
+      document.body.classList.remove('v--modal-block-scroll')
+    }
   },
   computed: {
     /**


### PR DESCRIPTION
Blocked scroll class should be removed on component destroy.

If modal have some route links and user goes to another page modal window doesn't close and doesn't remove class on body that blocks scroll.