### PR TITLE
corrected default class name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ There is also a ssr build with css file extracted. Take a look in /dist folder.
 | reset     | false | Boolean          | false       | Resets position and size before showing modal |
 | clickToClose | false | Boolean       | true        | If set to `false`, it will not be possible to close modal by clicking on the background |
 | transition| false | String           |             | Transition name |
-| classes   | false | [String, Array]  | 'v--modal'| Classes that will be applied to the actual modal box, if not specified, the default 'vue--modal' class will be applied |
+| classes   | false | [String, Array]  | 'v--modal'| Classes that will be applied to the actual modal box, if not specified, the default 'v--modal' class will be applied |
 | width     | false | [String, Number] | 600         | Width in pixels or percents (e.g. 50 or "50px", "50%") |
 | height    | false | [String, Number] | 300         | Height in pixels or percents (e.g. 50 or "50px", "50%") or `"auto"` |
 | minWidth  | false | Number (px)      | 0           | The minimum width to which modal can be resized  |


### PR DESCRIPTION
The readme description wrongly says "vue--modal" is the default class of the modal. This PR changes it to the correct "v--modal" class.