### PR TITLE
allow component to be rendered in modal

### DIFF
--- a/src/Dialog.vue
+++ b/src/Dialog.vue
@@ -17,8 +17,14 @@
         class="dialog-c-title"
         v-if="params.title"
         v-html="params.title || ''"></div>
+      <component
+        v-if="params.component"
+        v-bind="params.props"
+        :is="params.component">
+      </component>
       <div
         class="dialog-c-text"
+        v-else
         v-html="params.text || ''"></div>
     </div>
     <div


### PR DESCRIPTION
This allows components to be rendered as the main element in the modal's body.

```js
this.$modal.show('dialog', {
    // This is the component
    component: this.to,
    // This is the component's props
    props: this.props,
    scrollable: true
});
```