### PR TITLE
close modal when not subject of a toggle event

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -352,6 +352,10 @@ export default {
 
         this.toggle(nextState, params)
       }
+      
+      if (this.name !== name && this.visible) {
+        this.toggle(false, params)
+      }
     },
     /**
      * Initializes modal's size & position,


### PR DESCRIPTION
close modal if it's not the subject of a toggle event, to avoid having multiple modals opened at the same time

ref: https://github.com/euvl/vue-js-modal/issues/222