### PR TITLE
Use PascalCase names for component registration

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import Modal from './Modal.vue'
 import Dialog from './Dialog.vue'
 import ModalsContainer from './ModalsContainer.vue'
 
-const defaultComponentName = 'modal'
+const defaultComponentName = 'Modal'
 const unmountedRootErrorMessage =
   '[vue-js-modal] In order to render dynamic modals, a <modals-container> ' +
   'component must be present on the page'
@@ -59,13 +59,13 @@ const Plugin = {
      * Registration of <Dialog/> component
      */
     if (options.dialog) {
-      Vue.component('v-dialog', Dialog)
+      Vue.component('VDialog', Dialog)
     }
     /**
      * Registration of <ModalsContainer/> component
      */
     if (options.dynamic) {
-      Vue.component('modals-container', ModalsContainer)
+      Vue.component('ModalsContainer', ModalsContainer)
       Vue.mixin({
         beforeMount () {
           if (Plugin.rootInstance === null) {


### PR DESCRIPTION
The Vue style guide strongly recommends using PascalCase for component names:

> In most projects, component names should always be PascalCase in single-file components and string templates - but kebab-case in DOM templates.

Registering the components with PascalCase lets them be used as either PascalCase or kebab-case. So `VDialog` lets it be referred to as either `VDialog` or `v-dialog`.

As such this change shouldn't break anything, just make it work better with PascalCase.