### PR TITLE
Fix types: async component for show()

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import Vue, { PluginObject, ComponentOptions } from "vue";
+import Vue, { PluginObject, ComponentOptions, AsyncComponent } from "vue";
 
 declare const VueJSModal: PluginObject<VueJSModalOptions> & {
   rootInstance?: Vue
@@ -11,7 +11,7 @@ export declare interface VueJSModalOptions {
 }
 
 declare interface VModal {
-  show(modal: string | typeof Vue | ComponentOptions<Vue>, paramsOrProps?: object, params?: object, events?: object): void;
+  show(modal: string | typeof Vue | ComponentOptions<Vue> | AsyncComponent, paramsOrProps?: object, params?: object, events?: object): void;
   hide(name: string, params?: object): void;
   toggle(name: string, params?: object): void;
 }


### PR DESCRIPTION
```ts
this.$modal.show(() => import('./some/Component.vue'));
```

Currently, TypeScript throw this error on build:

```
Argument of type '() => Promise<typeof "Component.vue">' is not assignable to parameter of type 'string | VueConstructor<Vue> | ComponentOptions<Vue, DefaultData<Vue>, DefaultMethods<Vue>, Defau...'.
  Type '() => Promise<typeof "Component.vue">' has no properties in common with type 'ComponentOptions<Vue, DefaultData<Vue>, DefaultMethods<Vue>, DefaultComputed, PropsDefinition<Rec...'.
```

This little PR fix it