### PR TITLE
fix hover background color on buttons

### DIFF
--- a/src/Dialog.vue
+++ b/src/Dialog.vue
@@ -165,11 +165,11 @@ export default {
 }
 
 .vue-dialog-button:hover {
-  background: rgba(0, 0, 0, 0.01);
+  background: rgba(0, 0, 0, 0.1);
 }
 
 .vue-dialog-button:active {
-  background: rgba(0, 0, 0, 0.025);
+  background: rgba(0, 0, 0, 0.25);
 }
 
 .vue-dialog-button:not(:first-of-type) {


### PR DESCRIPTION
Changed the background color on buttons in hover from rgba(0, 0, 0, 0.01) to brgba(0, 0, 0, 0.1) , because the old one was really not showing any effect since it was practically all transparent .
Also did the same with the active effect .