### PR TITLE
if props (for example, width) have been changed after window.resize. Have added attribute scrollable in Dialog.vue

### DIFF
--- a/src/Dialog.vue
+++ b/src/Dialog.vue
@@ -4,6 +4,7 @@
     height="auto"
     :classes="['v--modal', 'vue-dialog', this.params.class]"
     :width="width"
+    :scrollable="scrollable"
     :pivot-y="0.3"
     :adaptive="true"
     :clickToClose="clickToClose"
@@ -59,6 +60,10 @@ export default {
     transition: {
       type: String,
       default: 'fade'
+    },
+    scrollable: {
+      type: Boolean,
+      default: false
     }
   },
   data () {

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -182,9 +182,12 @@ export default {
     * if props (for example, width) have been changed after window.resize, we should recalc modal sizes  
   */
   mounted() {
-    window.addEventListener('resize', () => {
-      this.setInitialSize();
-    });
+    if(this.draggable === false && this.resizable === false)
+    {
+      window.addEventListener('resize', () => {
+        this.setInitialSize();
+      });
+    }
   },
 
   /**

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -177,6 +177,16 @@ export default {
   created () {
     this.setInitialSize()
   },
+
+  /* 
+    * if props (fpr example, width) have been changed after window.resize, we should recalc modal sizes  
+  */
+  mounted() {
+    window.addEventListener('resize', () => {
+      this.setInitialSize();
+    });
+  },
+
   /**
    * Sets global listeners
    */

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -179,7 +179,7 @@ export default {
   },
 
   /* 
-    * if props (fpr example, width) have been changed after window.resize, we should recalc modal sizes  
+    * if props (for example, width) have been changed after window.resize, we should recalc modal sizes  
   */
   mounted() {
     window.addEventListener('resize', () => {


### PR DESCRIPTION
if props (for example, width) have been changed after window.resize, we shoud call this.setInitialSize()

Have added attribute scrollable in Dialog.vue