### PR TITLE
fix dynamicDefaults to use params instead of props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ const Plugin = {
     this.installed = true
     this.event = new Vue()
     this.rootInstance = null
-    
+
     const componentName = options.componentName || defaultComponentName
     const dynamicDefaults = options.dynamicDefaults || {}
     /**
@@ -64,7 +64,7 @@ const Plugin = {
        * Show dynamic modal
        */
       if (container) {
-        container.add(modal, { ...dynamicDefaults, ...props }, params, events)
+        container.add(modal, props, { ...dynamicDefaults, ...params }, events)
         return
       }
 


### PR DESCRIPTION
In the documentation, it shows an example of use of [DynamicDefaults](https://github.com/euvl/vue-js-modal#dynamic-modals) property to set the defaults parameters for a modal like height, scrollable, etc.

The problem is that is not how it works, because it really replaces the `props` of a modal.