### PR TITLE
Patched resizer to faciliate max width/height

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -32,6 +32,8 @@
               v-if="resizable && !isAutoHeight"
               :min-width="minWidth"
               :min-height="minHeight"
+              :max-width='maxWidth'
+              :max-height='maxHeight'
               @resize="handleModalResize"
             />
           </div>

--- a/src/Resizer.vue
+++ b/src/Resizer.vue
@@ -14,6 +14,14 @@ export default {
     minWidth: {
       type: Number,
       default: 0
+    },
+    maxWidth: {
+      type: Number,
+      default: 9999
+    },
+    maxHeight: {
+      type: Number,
+      default: 9999
     }
   },
   data () {
@@ -56,13 +64,14 @@ export default {
     },
     resize (event) {
       var el = this.$el.parentElement
-
       if (el) {
         var width = event.clientX - el.offsetLeft
         var height = event.clientY - el.offsetTop
-
         width = inRange(this.minWidth, window.innerWidth, width)
         height = inRange(this.minHeight, window.innerHeight, height)
+        // My adjustment here //
+        if( this.maxWidth && width > this.maxWidth) width = this.maxWidth
+        if( this.maxHeight && height > this.maxHeight) height = this.maxHeight
 
         this.size = { width, height }
         el.style.width = width + 'px'


### PR DESCRIPTION
Small change to allow for resizer to accept and utilize max width/height params from modal. Regarding issue https://github.com/euvl/vue-js-modal/issues/451