### PR TITLE
Update Modal.vue to add Aria role

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -26,6 +26,8 @@
             ref="modal"
             :class="modalClass"
             :style="modalStyle"
+            role="dialog"
+            aria-modal="true"
           >
             <slot/>
             <resizer


### PR DESCRIPTION
This is important so screen readers can read modal for visually impaired users.