### PR TITLE
Add scarf-js for anonymized installation analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Demo: http://vue-js-modal.yev.io/
 npm install vue-js-modal --save
 ```
 
+> Please note: Vue.js modal uses [Scarf](https://www.npmjs.com/package/@scarf/scarf) to collect anonymized installation analytics. These analytics help support the maintainers of this library. However, if you'd like to opt out, you can do so by setting `scarfSettings.enabled = false` in your project's package.json. Alternatively, you can set the environment variable `SCARF_ANALYTICS=false`.
+
 ### How to use
 
 Include plugin in your `main.js` file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-js-modal",
-  "version": "2.0.0-next.0",
+  "version": "2.0.0-rc.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -712,6 +712,11 @@
         "lodash": "^4.17.10",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@scarf/scarf": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.0.4.tgz",
+      "integrity": "sha512-lkhjzeYyYAG4VvdrjvbZCOYzXH5vCwfzYj9xJ4zHDgyYIOzObZwcsbW6W1q5Z4tywrb14oG/tfsFAMMQPCTFqw=="
     },
     "@types/color-name": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "browserslist": "> 0.25%, not dead",
   "dependencies": {
+    "@scarf/scarf": "^1.0.4",
     "resize-observer-polyfill": "^1.5.1"
   }
 }


### PR DESCRIPTION
👋 Thanks for all the work on vue-js-modal! I noticed this package is using GitHub Sponsors - In efforts to help support the project, this change adds scarf-js for installation analytics. By adding this dependency, the metrics you'll collect will provide insight into how your package is being and by which companies. The data will be available to you (and any co-maintainers you wish to authorize) on https://scarf.sh. If you're interested, the Scarf team can reach out to these companies to drive more financial support for your package or even help set up support contracts. Scarf-js will transparently inform the user about the analytics and how they can opt out.