### PR TITLE
Support auto and adaptive modes together

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -356,6 +356,16 @@ export default {
       return value
     },
 
+    /**
+     * Returns the height of the modal when in 'auto' mode, making sure the
+     * modal fits the viewport if 'adaptive' is also true
+     */
+    autoHeight() {
+      return this.adaptive && this.modal.renderedHeight >= this.viewportHeight
+        ? this.viewportHeight + 'px'
+        : 'auto';
+    },
+
     containerClass() {
       return [
         'vm--container',
@@ -385,7 +395,7 @@ export default {
           top: this.position.top + 'px',
           left: this.position.left + 'px',
           width: this.trueModalWidth + 'px',
-          height: this.isAutoHeight ? 'auto' : this.trueModalHeight + 'px'
+          height: this.isAutoHeight ? this.autoHeight : this.trueModalHeight + 'px'
         }
       ]
     },

--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -362,7 +362,7 @@ export default {
      */
     autoHeight() {
       return this.adaptive && this.modal.renderedHeight >= this.viewportHeight
-        ? this.viewportHeight + 'px'
+        ? Math.max(this.minHeight, this.viewportHeight) + 'px'
         : 'auto';
     },
 


### PR DESCRIPTION
I would like to be able to use both "adaptive" and "height=auto" modes together. That is, the height should be auto as long as it fits in the viewport, but should be adaptive (shrink with the viewport) if the auto height is greater than the viewport.