### PR TITLE
Adding hideAll to type definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,6 +17,7 @@ declare interface VModal {
     | ComponentOptions<Vue> 
     | AsyncComponent, paramsOrProps?: object, params?: object, events?: object): void;
   hide(name: string, params?: object): void;
+  hideAll(): void;
   toggle(name: string, params?: object): void;
 }
 


### PR DESCRIPTION
In the latest releases, it was introduced a method called hideAll() for dynamic modals. It's type definition was missed