### PR TITLE
Make scale transitions work when height is auto - Fixes #281

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -299,7 +299,9 @@ export default {
 
       return {
         left: parseInt(inRange(0, maxLeft, left)),
-        top: parseInt(inRange(0, maxTop, top))
+        top: !trueModalHeight && this.isAutoHeight
+          ? undefined
+          : parseInt(inRange(0, maxTop, top))
       }
     },
     /**


### PR DESCRIPTION
Makes it possible to set modal transitions that has a scale without the animation being ruined when height: 'auto'.
These changes make sure to only specify a top-position after the height of the contents is known.
Also solves https://github.com/euvl/vue-js-modal/issues/281
Potential fix for https://github.com/euvl/vue-js-modal/issues/346