### PR TITLE
fix: code typo in intro.md

### DIFF
--- a/docs/Intro.md
+++ b/docs/Intro.md
@@ -27,7 +27,7 @@ export default {
             this.$modal.hide('my-first-modal');
         }
     },
-    mount () {
+    mounted () {
         this.show()
     }
 }


### PR DESCRIPTION
## Code typo in docs (intro.md)
`mount` should be `mounted`.
Thanks!