### PR TITLE
Upgraded Resizer for modal

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -1,17 +1,75 @@
 
-.vue-modal-resizer {
+.vue-modal-top,
+.vue-modal-bottom,
+.vue-modal-left,
+.vue-modal-right,
+.vue-modal-topRight,
+.vue-modal-topLeft,
+.vue-modal-bottomLeft,
+.vue-modal-bottomRight {
   display: block;
   overflow: hidden;
   position: absolute;
+  background: transparent;
+  z-index: 9999999;
+}
+.vue-modal-topRight,
+.vue-modal-topLeft,
+.vue-modal-bottomLeft,
+.vue-modal-bottomRight {
   width: 12px;
   height: 12px;
+}
+.vue-modal-top {
+  right: 12;
+  top: 0;
+  width: 100%;
+  height: 12px;
+  cursor: n-resize;
+}
+.vue-modal-bottom {
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 12px;
+  cursor: s-resize;
+}
+.vue-modal-left {
+  left: 0;
+  top: 0;
+  width: 12px;
+  height: 100%;
+  cursor: w-resize;
+}
+.vue-modal-right {
+  right: 0;
+  top: 0;
+  width: 12px;
+  height: 100%;
+  cursor: e-resize;
+}
+.vue-modal-topRight {
+  right: 0;
+  top: 0;
+  background: transparent;
+  cursor: ne-resize;
+}
+.vue-modal-topLeft {
+  left: 0;
+  top: 0;
+  cursor: nw-resize;
+}
+.vue-modal-bottomLeft {
+  left: 0;
+  bottom: 0;
+  cursor: sw-resize;
+}
+.vue-modal-bottomRight {
   right: 0;
   bottom: 0;
-  z-index: 9999999;
-  background: transparent;
   cursor: se-resize;
 }
-.vue-modal-resizer::after {
+#vue-modal-triangle::after {
   display: block;
   position: absolute;
   content: '';
@@ -23,7 +81,7 @@
   border-bottom: 10px solid #ddd;
   border-left: 10px solid transparent;
 }
-.vue-modal-resizer.clicked::after {
+#vue-modal-triangle.clicked::after {
   border-bottom: 10px solid #369be9;
 }
 

--- a/docs/Properties.md
+++ b/docs/Properties.md
@@ -18,7 +18,7 @@ Enables resizing of the modal.
 
 ---
 
-#### `resizeEdges: Array<String> default: ['r', 'br', 'b', 'bl', 'l', 'tl', 't', 'tr']`
+#### `resizeEdges: Array<String>` `default: ['r', 'br', 'b', 'bl', 'l', 'tl', 't', 'tr']`
 
 Can contain an array with the edges on which you want the modal to be able to resize on.
 | string | corner |
@@ -34,13 +34,13 @@ Can contain an array with the edges on which you want the modal to be able to re
 
 ---
 
-#### `resizeIndicator: Boolean default: true`
+#### `resizeIndicator: Boolean` `default: true`
 
 Enables the resize triangle at the bottom right of a modal when Resizable is enabled.
 
 ---
 
-#### `centerResize: Boolean default: true`
+#### `centerResize: Boolean` `default: true`
 
 Enables automatic centering of the modal when resizing, if disabled modals will resize and remain in a fixed position similar to how Windows applications are resized.
 

--- a/docs/Properties.md
+++ b/docs/Properties.md
@@ -12,15 +12,43 @@ Name of the modal, it is required property.
 
 ---
 
-#### `resizable: Boolean` 
+#### `resizable: Boolean`
 
 Enables resizing of the modal.
 
 ---
 
+#### `resizeEdges: Array<String> default: ['r', 'br', 'b', 'bl', 'l', 'tl', 't', 'tr']`
+
+Can contain an array with the edges on which you want the modal to be able to resize on.
+| string | corner |
+| ------- | ------------- |
+| r | right |
+| br | bottom right |
+| b | bottom |
+| bl | bottom left |
+| l | left |
+| t | top left |
+| t | top |
+| tr | top right |
+
+---
+
+#### `resizeIndicator: Boolean default: true`
+
+Enables the resize triangle at the bottom right of a modal when Resizable is enabled.
+
+---
+
+#### `centerResize: Boolean default: true`
+
+Enables automatic centering of the modal when resizing, if disabled modals will resize and remain in a fixed position similar to how Windows applications are resized.
+
+---
+
 #### `adaptive: Boolean`
 
-Enable responsive behavior, modal will try to adapt to the screen size when possible. Properties  `maxHeight`, `maxWidth`, `minHeight`, `minWidth` can set the boundaries for the automatic resizing.
+Enable responsive behavior, modal will try to adapt to the screen size when possible. Properties `maxHeight`, `maxWidth`, `minHeight`, `minWidth` can set the boundaries for the automatic resizing.
 
 ---
 
@@ -78,7 +106,7 @@ Resets position and size before showing
 
 ---
 
-#### `clickToClose: Boolean`  `default: true`
+#### `clickToClose: Boolean` `default: true`
 
 If set to `false`, it will not be possible to close modal by clicking on the background or by pressing Esc key.
 
@@ -102,42 +130,41 @@ List of class that will be applied to the modal window (not overlay, just the bo
 
 ---
 
-#### `styles: String | Array | Object` 
+#### `styles: String | Array | Object`
 
 Style that will be applied to the modal window.
 
-
 ::: warning Note
-To be able to support string definition of styles there are some hacks in place. 
+To be able to support string definition of styles there are some hacks in place.
 
 Vue.js does not allow merging string css definition with an object/array style definition. There are very few cases where you might need to use this property, but if you do - write tests :)
 :::
 
 ---
 
-#### `width: String | Number` `default: 600`     
+#### `width: String | Number` `default: 600`
 
 Width in pixels or percents (50, "50px", "50%").
 
 Supported string values are `<number>%` and `<number>px`
 
 ::: warning Note
-This is not CSS size value, it does not support `em`, `pem`, etc. Plugin requires pixels to recalculate position and size for draggable, resaziable modal. 
+This is not CSS size value, it does not support `em`, `pem`, etc. Plugin requires pixels to recalculate position and size for draggable, resaziable modal.
 If you need to use more value types, please consider contributing to the parser [here](https://github.com/euvl/vue-js-modal/blob/master/src/utils/parser.js).
-:::   
+:::
 
 ---
 
 #### `height: String | Number` `default: 300`
 
-Height in pixels or percents (50, "50px", "50%") or `"auto"`.                       
- 
+Height in pixels or percents (50, "50px", "50%") or `"auto"`.
+
 Supported string values are `<number>%`, `<number>px` and `auto`. Setting height to `"auto"` makes it automatically change the height when the content size changes (this works well with `scrollable` feature).
 
 ::: warning Note
-This is not CSS size value, it does not support `em`, `pem`, etc. Plugin requires pixels to recalculate position and size for draggable, resaziable modal. 
+This is not CSS size value, it does not support `em`, `pem`, etc. Plugin requires pixels to recalculate position and size for draggable, resaziable modal.
 If you need to use more value types, please consider contributing to the parser [here](https://github.com/euvl/vue-js-modal/blob/master/src/utils/parser.js).
-:::   
+:::
 
 ---
 
@@ -177,7 +204,8 @@ Vertical position in `%`, default is `0.5` (meaning that modal box will be in th
 
 ---
 
-## Example 
+## Example
+
 ```html
 <template>
   <modal name="example"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-js-modal",
-  "version": "2.0.0-rc.5",
+  "version": "2.0.0-rc.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -571,7 +571,6 @@ export default {
         this.shiftLeft = this.getResizedShiftLeft(event)
         this.shiftTop = this.getResizedShiftTop(event)
       }
-      //this.shiftLeft = this.shiftLeft - 1
 
       const { size } = this.modal
 
@@ -582,6 +581,11 @@ export default {
         })
       )
     },
+
+    /**
+     * When centerResize is set to false, the modal has to be shifted so the position of the modal stays fixed.
+     * This method shifts the modal in the x direction.
+     */
     getResizedShiftLeft(event) {
       const {
         viewportHeight,
@@ -612,6 +616,10 @@ export default {
 
       return result
     },
+    /**
+     * When centerResize is set to false, the modal has to be shifted so the position of the modal stays fixed.
+     * This method shifts the modal in the y direction.
+     */
     getResizedShiftTop(event) {
       const {
         viewportHeight,

--- a/src/components/Resizer.vue
+++ b/src/components/Resizer.vue
@@ -1,5 +1,14 @@
 <template>
-  <div :class="className"></div>
+  <div>
+      <div v-if="this.resizeEdges.includes('t')" class="vue-modal-top"></div>
+      <div v-if="this.resizeEdges.includes('b')" class="vue-modal-bottom"></div>
+      <div v-if="this.resizeEdges.includes('l')" class="vue-modal-left"></div>
+      <div v-if="this.resizeEdges.includes('r')" class="vue-modal-right"></div>
+      <div v-if="this.resizeEdges.includes('tr')" class="vue-modal-topRight"></div>
+      <div v-if="this.resizeEdges.includes('tl')" class="vue-modal-topLeft"></div>
+      <div v-if="this.resizeEdges.includes('br')" :id="getID" :class="className"></div>
+      <div v-if="this.resizeEdges.includes('bl')" class="vue-modal-bottomLeft"></div>
+  </div>
 </template>
 <script>
 import { inRange, windowWidthWithoutScrollbar } from '../utils'
@@ -22,12 +31,31 @@ export default {
     maxHeight: {
       type: Number,
       default: Number.MAX_SAFE_INTEGER
+    },
+    viewportWidth: {
+      type: Number,
+      required: true
+    },
+    viewportHeight: {
+      type: Number,
+      required: true
+    },
+    resizeIndicator: {
+      type: Boolean,
+      default: true
+    },
+    resizeEdges: {
+      type: Array,
+      required: true
     }
   },
   data() {
     return {
       clicked: false,
-      size: {}
+      targetClass: '',
+      size: {},
+      initialX: 0,
+      initialY: 0
     }
   },
   mounted() {
@@ -36,12 +64,19 @@ export default {
   computed: {
     className() {
       const { clicked } = this
-      return ['vue-modal-resizer', { clicked }]
+      return ['vue-modal-bottomRight', { clicked }]
+    },
+    getID() {
+      if (this.resizeIndicator) return 'vue-modal-triangle'
+      else return ''
     }
   },
   methods: {
     start(event) {
+      this.targetClass = event.target.className
       this.clicked = true
+      this.initialX = event.clientX
+      this.initialY = event.clientY
 
       window.addEventListener('mousemove', this.mousemove, false)
       window.addEventListener('mouseup', this.stop, false)
@@ -52,6 +87,10 @@ export default {
 
     stop() {
       this.clicked = false
+      this.clicked = false
+      this.targetClass = ''
+      this.initialX = 0
+      this.initialY = 0
 
       window.removeEventListener('mousemove', this.mousemove, false)
       window.removeEventListener('mouseup', this.stop, false)
@@ -69,23 +108,84 @@ export default {
     resize(event) {
       var el = this.$el.parentElement
 
+      var width = event.clientX
+      var height = event.clientY
+
+      if (event.clientX > this.viewportWidth || event.clientX < 0) return
+      if (event.clientY > this.viewportHeight || event.clientY < 0) return
+
       if (el) {
-        var width = event.clientX - el.offsetLeft
-        var height = event.clientY - el.offsetTop
+        switch (this.targetClass) {
+          case 'vue-modal-right':
+            width = width - el.offsetLeft
+            height = parseInt(el.style.height.replace('px', ''))
+            break
+          case 'vue-modal-left':
+            height = parseInt(el.style.height.replace('px', ''))
+            width =
+              parseInt(el.style.width.replace('px', '')) +
+              (this.initialX - event.clientX)
+            break
+          case 'vue-modal-top':
+            width = parseInt(el.style.width.replace('px', ''))
+            height =
+              parseInt(el.style.height.replace('px', '')) +
+              (this.initialY - event.clientY)
+            break
+          case 'vue-modal-bottom':
+            width = parseInt(el.style.width.replace('px', ''))
+            height = height - el.offsetTop
+            break
+          case 'vue-modal-bottomRight':
+            width = width - el.offsetLeft
+            height = height - el.offsetTop
+            break
+          case 'vue-modal-topRight':
+            width = width - el.offsetLeft
+            height =
+              parseInt(el.style.height.replace('px', '')) +
+              (this.initialY - event.clientY)
+            break
+          case 'vue-modal-bottomLeft':
+            width =
+              parseInt(el.style.width.replace('px', '')) +
+              (this.initialX - event.clientX)
+            height = height - el.offsetTop
+            break
+          case 'vue-modal-topLeft':
+            width =
+              parseInt(el.style.width.replace('px', '')) +
+              (this.initialX - event.clientX)
+            height =
+              parseInt(el.style.height.replace('px', '')) +
+              (this.initialY - event.clientY)
+            break
+          default:
+            console.error('Incorrrect/no resize direction.')
+        }
 
         const maxWidth = Math.min(windowWidthWithoutScrollbar(), this.maxWidth)
         const maxHeight = Math.min(window.innerHeight, this.maxHeight)
-
         width = inRange(this.minWidth, maxWidth, width)
         height = inRange(this.minHeight, maxHeight, height)
+        this.initialX = event.clientX
+        this.initialY = event.clientY
 
         this.size = { width, height }
+
+        const dimGrowth = {
+          width: width - parseInt(el.style.width.replace('px', '')),
+          height: height - parseInt(el.style.height.replace('px', ''))
+        }
+
         el.style.width = width + 'px'
         el.style.height = height + 'px'
 
         this.$emit('resize', {
           element: el,
-          size: this.size
+          size: this.size,
+          direction: this.targetClass,
+          dimGrowth: dimGrowth
         })
       }
     }
@@ -93,7 +193,95 @@ export default {
 }
 </script>
 <style>
-.vue-modal-resizer {
+.vue-modal-top {
+  display: block;
+  overflow: hidden;
+  position: absolute;
+  width: 100%;
+  height: 12px;
+  right: 12;
+  top: 0;
+  z-index: 9999999;
+  background: transparent;
+  cursor: n-resize;
+}
+
+.vue-modal-bottom {
+  display: block;
+  overflow: hidden;
+  position: absolute;
+  width: 100%;
+  height: 12px;
+  left: 0;
+  bottom: 0;
+  z-index: 9999999;
+  background: transparent;
+  cursor: s-resize;
+}
+
+.vue-modal-left {
+  display: block;
+  overflow: hidden;
+  position: absolute;
+  width: 12px;
+  height: 100%;
+  left: 0;
+  top: 0;
+  z-index: 9999999;
+  background: transparent;
+  cursor: w-resize;
+}
+
+.vue-modal-right {
+  display: block;
+  overflow: hidden;
+  position: absolute;
+  width: 12px;
+  height: 100%;
+  right: 0;
+  top: 0;
+  z-index: 9999999;
+  background: transparent;
+  cursor: e-resize;
+}
+
+.vue-modal-topRight {
+  display: block;
+  overflow: hidden;
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  right: 0;
+  top: 0;
+  z-index: 9999999;
+  background: transparent;
+  cursor: ne-resize;
+}
+.vue-modal-topLeft {
+  display: block;
+  overflow: hidden;
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  left: 0;
+  top: 0;
+  z-index: 9999999;
+  background: transparent;
+  cursor: nw-resize;
+}
+.vue-modal-bottomLeft {
+  display: block;
+  overflow: hidden;
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  left: 0;
+  bottom: 0;
+  z-index: 9999999;
+  background: transparent;
+  cursor: sw-resize;
+}
+.vue-modal-bottomRight {
   display: block;
   overflow: hidden;
   position: absolute;
@@ -106,7 +294,7 @@ export default {
   cursor: se-resize;
 }
 
-.vue-modal-resizer::after {
+#vue-modal-triangle::after {
   display: block;
   position: absolute;
   content: '';
@@ -119,7 +307,7 @@ export default {
   border-left: 10px solid transparent;
 }
 
-.vue-modal-resizer.clicked::after {
+#vue-modal-triangle.clicked::after {
   border-bottom: 10px solid #369be9;
 }
 </style>

--- a/src/components/Resizer.vue
+++ b/src/components/Resizer.vue
@@ -104,6 +104,10 @@ export default {
     mousemove(event) {
       this.resize(event)
     },
+    parseDim(el, dim) {
+      if(dim === "w") return parseInt(el.style.width.replace('px', ''))
+      else return parseInt(el.style.height.replace('px', ''))
+    }
 
     resize(event) {
       var el = this.$el.parentElement
@@ -120,22 +124,22 @@ export default {
         switch (this.targetClass) {
           case 'vue-modal-right':
             width = width - el.offsetLeft
-            height = parseInt(el.style.height.replace('px', ''))
+            height = parseDim(el, "h")
             break
           case 'vue-modal-left':
-            height = parseInt(el.style.height.replace('px', ''))
+            height = parseDim(el, "h")
             width =
-              parseInt(el.style.width.replace('px', '')) +
+              parseDim(el, "w") +
               (this.initialX - event.clientX)
             break
           case 'vue-modal-top':
-            width = parseInt(el.style.width.replace('px', ''))
+            width = parseDim(el, "w")
             height =
-              parseInt(el.style.height.replace('px', '')) +
+              parseDim(el, "h") +
               (this.initialY - event.clientY)
             break
           case 'vue-modal-bottom':
-            width = parseInt(el.style.width.replace('px', ''))
+            width = parseDim(el, "w")
             height = height - el.offsetTop
             break
           case 'vue-modal-bottomRight':
@@ -145,21 +149,21 @@ export default {
           case 'vue-modal-topRight':
             width = width - el.offsetLeft
             height =
-              parseInt(el.style.height.replace('px', '')) +
+              parseDim(el, "h") +
               (this.initialY - event.clientY)
             break
           case 'vue-modal-bottomLeft':
             width =
-              parseInt(el.style.width.replace('px', '')) +
+              parseDim(el, "w") +
               (this.initialX - event.clientX)
             height = height - el.offsetTop
             break
           case 'vue-modal-topLeft':
             width =
-              parseInt(el.style.width.replace('px', '')) +
+              parseDim(el, "w") +
               (this.initialX - event.clientX)
             height =
-              parseInt(el.style.height.replace('px', '')) +
+              parseDim(el, "h") +
               (this.initialY - event.clientY)
             break
           default:
@@ -177,8 +181,8 @@ export default {
 
         //Calculate growth in each dimension to be used when shifting the modal.
         const dimGrowth = {
-          width: width - parseInt(el.style.width.replace('px', '')),
-          height: height - parseInt(el.style.height.replace('px', ''))
+          width: width - parseDim(el, "w"),
+          height: height - parseDim(el, "h")
         }
 
         el.style.width = width + 'px'

--- a/src/components/Resizer.vue
+++ b/src/components/Resizer.vue
@@ -104,16 +104,13 @@ export default {
     mousemove(event) {
       this.resize(event)
     },
-    parseDim(el, dim) {
-      if(dim === "w") return parseInt(el.style.width.replace('px', ''))
-      else return parseInt(el.style.height.replace('px', ''))
-    }
-
     resize(event) {
       var el = this.$el.parentElement
 
       var width = event.clientX
       var height = event.clientY
+      var styleWidth = parseInt(el.style.width.replace('px', ''))
+      var styleHeight = parseInt(el.style.height.replace('px', ''))
 
       //Block Resize if mouse outside visable space.
       if (event.clientX > this.viewportWidth || event.clientX < 0) return
@@ -124,22 +121,18 @@ export default {
         switch (this.targetClass) {
           case 'vue-modal-right':
             width = width - el.offsetLeft
-            height = parseDim(el, "h")
+            height = styleHeight
             break
           case 'vue-modal-left':
-            height = parseDim(el, "h")
-            width =
-              parseDim(el, "w") +
-              (this.initialX - event.clientX)
+            height = styleHeight
+            width = styleWidth + (this.initialX - event.clientX)
             break
           case 'vue-modal-top':
-            width = parseDim(el, "w")
-            height =
-              parseDim(el, "h") +
-              (this.initialY - event.clientY)
+            width = styleWidth
+            height = styleHeight + (this.initialY - event.clientY)
             break
           case 'vue-modal-bottom':
-            width = parseDim(el, "w")
+            width = styleWidth
             height = height - el.offsetTop
             break
           case 'vue-modal-bottomRight':
@@ -148,23 +141,15 @@ export default {
             break
           case 'vue-modal-topRight':
             width = width - el.offsetLeft
-            height =
-              parseDim(el, "h") +
-              (this.initialY - event.clientY)
+            height = styleHeight + (this.initialY - event.clientY)
             break
           case 'vue-modal-bottomLeft':
-            width =
-              parseDim(el, "w") +
-              (this.initialX - event.clientX)
+            width = styleWidth + (this.initialX - event.clientX)
             height = height - el.offsetTop
             break
           case 'vue-modal-topLeft':
-            width =
-              parseDim(el, "w") +
-              (this.initialX - event.clientX)
-            height =
-              parseDim(el, "h") +
-              (this.initialY - event.clientY)
+            width = styleWidth + (this.initialX - event.clientX)
+            height = styleHeight + (this.initialY - event.clientY)
             break
           default:
             console.error('Incorrrect/no resize direction.')
@@ -181,8 +166,8 @@ export default {
 
         //Calculate growth in each dimension to be used when shifting the modal.
         const dimGrowth = {
-          width: width - parseDim(el, "w"),
-          height: height - parseDim(el, "h")
+          width: width - styleWidth,
+          height: height - styleHeight
         }
 
         el.style.width = width + 'px'

--- a/src/components/Resizer.vue
+++ b/src/components/Resizer.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
-      <div v-if="this.resizeEdges.includes('t')" class="vue-modal-top"></div>
-      <div v-if="this.resizeEdges.includes('b')" class="vue-modal-bottom"></div>
-      <div v-if="this.resizeEdges.includes('l')" class="vue-modal-left"></div>
-      <div v-if="this.resizeEdges.includes('r')" class="vue-modal-right"></div>
-      <div v-if="this.resizeEdges.includes('tr')" class="vue-modal-topRight"></div>
-      <div v-if="this.resizeEdges.includes('tl')" class="vue-modal-topLeft"></div>
-      <div v-if="this.resizeEdges.includes('br')" :id="getID" :class="className"></div>
-      <div v-if="this.resizeEdges.includes('bl')" class="vue-modal-bottomLeft"></div>
+    <div v-if="this.resizeEdges.includes('t')" class="vue-modal-top"></div>
+    <div v-if="this.resizeEdges.includes('b')" class="vue-modal-bottom"></div>
+    <div v-if="this.resizeEdges.includes('l')" class="vue-modal-left"></div>
+    <div v-if="this.resizeEdges.includes('r')" class="vue-modal-right"></div>
+    <div v-if="this.resizeEdges.includes('tr')" class="vue-modal-topRight"></div>
+    <div v-if="this.resizeEdges.includes('tl')" class="vue-modal-topLeft"></div>
+    <div v-if="this.resizeEdges.includes('br')" :id="getID" :class="className"></div>
+    <div v-if="this.resizeEdges.includes('bl')" class="vue-modal-bottomLeft"></div>
   </div>
 </template>
 <script>
@@ -184,104 +184,78 @@ export default {
 }
 </script>
 <style>
-.vue-modal-top {
-  display: block;
-  overflow: hidden;
-  position: absolute;
-  width: 100%;
-  height: 12px;
-  right: 12;
-  top: 0;
-  z-index: 9999999;
-  background: transparent;
-  cursor: n-resize;
-}
-
-.vue-modal-bottom {
-  display: block;
-  overflow: hidden;
-  position: absolute;
-  width: 100%;
-  height: 12px;
-  left: 0;
-  bottom: 0;
-  z-index: 9999999;
-  background: transparent;
-  cursor: s-resize;
-}
-
-.vue-modal-left {
-  display: block;
-  overflow: hidden;
-  position: absolute;
-  width: 12px;
-  height: 100%;
-  left: 0;
-  top: 0;
-  z-index: 9999999;
-  background: transparent;
-  cursor: w-resize;
-}
-
-.vue-modal-right {
-  display: block;
-  overflow: hidden;
-  position: absolute;
-  width: 12px;
-  height: 100%;
-  right: 0;
-  top: 0;
-  z-index: 9999999;
-  background: transparent;
-  cursor: e-resize;
-}
-
-.vue-modal-topRight {
-  display: block;
-  overflow: hidden;
-  position: absolute;
-  width: 12px;
-  height: 12px;
-  right: 0;
-  top: 0;
-  z-index: 9999999;
-  background: transparent;
-  cursor: ne-resize;
-}
-.vue-modal-topLeft {
-  display: block;
-  overflow: hidden;
-  position: absolute;
-  width: 12px;
-  height: 12px;
-  left: 0;
-  top: 0;
-  z-index: 9999999;
-  background: transparent;
-  cursor: nw-resize;
-}
-.vue-modal-bottomLeft {
-  display: block;
-  overflow: hidden;
-  position: absolute;
-  width: 12px;
-  height: 12px;
-  left: 0;
-  bottom: 0;
-  z-index: 9999999;
-  background: transparent;
-  cursor: sw-resize;
-}
+.vue-modal-top,
+.vue-modal-bottom,
+.vue-modal-left,
+.vue-modal-right,
+.vue-modal-topRight,
+.vue-modal-topLeft,
+.vue-modal-bottomLeft,
 .vue-modal-bottomRight {
   display: block;
   overflow: hidden;
   position: absolute;
+  background: transparent;
+  z-index: 9999999;
+}
+.vue-modal-topRight,
+.vue-modal-topLeft,
+.vue-modal-bottomLeft,
+.vue-modal-bottomRight {
   width: 12px;
   height: 12px;
+}
+.vue-modal-top {
+  right: 12;
+  top: 0;
+  width: 100%;
+  height: 12px;
+  cursor: n-resize;
+}
+
+.vue-modal-bottom {
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 12px;
+  cursor: s-resize;
+}
+
+.vue-modal-left {
+  left: 0;
+  top: 0;
+  width: 12px;
+  height: 100%;
+  cursor: w-resize;
+}
+
+.vue-modal-right {
+  right: 0;
+  top: 0;
+  width: 12px;
+  height: 100%;
+  cursor: e-resize;
+}
+
+.vue-modal-topRight {
+  right: 0;
+  top: 0;
+  background: transparent;
+  cursor: ne-resize;
+}
+.vue-modal-topLeft {
+  left: 0;
+  top: 0;
+  cursor: nw-resize;
+}
+.vue-modal-bottomLeft {
+  left: 0;
+  bottom: 0;
+  cursor: sw-resize;
+}
+.vue-modal-bottomRight {
   right: 0;
   bottom: 0;
-  z-index: 9999999;
-  background: transparent;
   cursor: se-resize;
 }
 

--- a/src/components/Resizer.vue
+++ b/src/components/Resizer.vue
@@ -180,7 +180,6 @@ export default {
 
         el.style.width = width + 'px'
         el.style.height = height + 'px'
-
         this.$emit('resize', {
           element: el,
           size: this.size,


### PR DESCRIPTION
Worked with @Mirijam1 on upgrading the resizer for our work project.
Main changes are:

Modal.vue
- Resizing now works from all edges & all corners
- New prop `resizeEdges` to select which edges can be used to resize on (so setting it to only be bottom Right like before possible)
- New prop `centerResize` default true so behaves like before where the modal resizes while keeping it anchored to the center when false the modal resizes in a way similar to Windows applications.
- New prop `resizeIndicator` to disable the bottom right triangle
- On ModalResize now checks if the default centering of the modal should occur if not it will shift the modal.
- New method `getResizerShiftLeft` & `getResizerShiftRight` calculate and return the shiftLeft/Right prop for modal to keep its position fixed.

Resizer.vue
- Now creates multiple divs for each resizable edge Style for each div also included.
- New Prop `viewportWidth` & `viewportHeight` to block resizing when mouse goes out of bounds.
- New prop `resizeIndicator` to disable the bottom right triangle
- New prop `resizeEdges` to select which edges can be used to resize on (so setting it to only be bottom Right like before possible)
- Resize method reworked to calculate growth based on direction.
- Resize event emitted now includes the direction and growth in in dimension.