### PR TITLE
DynamicDefaults Typo in Documentation

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -42,7 +42,7 @@ Vue.use(VModal, { componentName: 'Foo' })
 Default properties that are injected into dynamic modals. 
 
 ```js
-Vue.use(VModal, { dynamicDefault: { draggable: true, resizable: true } })
+Vue.use(VModal, { dynamicDefaults: { draggable: true, resizable: true } })
 ```
 
 ## API


### PR DESCRIPTION
This PR is fixing a small (but crucial) typo in documentation (usage of dynamicDefault**s**)