### PR TITLE
Revert "Upgraded Resizer for modal"

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -1,75 +1,17 @@
 
-.vue-modal-top,
-.vue-modal-bottom,
-.vue-modal-left,
-.vue-modal-right,
-.vue-modal-topRight,
-.vue-modal-topLeft,
-.vue-modal-bottomLeft,
-.vue-modal-bottomRight {
+.vue-modal-resizer {
   display: block;
   overflow: hidden;
   position: absolute;
-  background: transparent;
+  width: 12px;
+  height: 12px;
+  right: 0;
+  bottom: 0;
   z-index: 9999999;
-}
-.vue-modal-topRight,
-.vue-modal-topLeft,
-.vue-modal-bottomLeft,
-.vue-modal-bottomRight {
-  width: 12px;
-  height: 12px;
-}
-.vue-modal-top {
-  right: 12;
-  top: 0;
-  width: 100%;
-  height: 12px;
-  cursor: n-resize;
-}
-.vue-modal-bottom {
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  height: 12px;
-  cursor: s-resize;
-}
-.vue-modal-left {
-  left: 0;
-  top: 0;
-  width: 12px;
-  height: 100%;
-  cursor: w-resize;
-}
-.vue-modal-right {
-  right: 0;
-  top: 0;
-  width: 12px;
-  height: 100%;
-  cursor: e-resize;
-}
-.vue-modal-topRight {
-  right: 0;
-  top: 0;
   background: transparent;
-  cursor: ne-resize;
-}
-.vue-modal-topLeft {
-  left: 0;
-  top: 0;
-  cursor: nw-resize;
-}
-.vue-modal-bottomLeft {
-  left: 0;
-  bottom: 0;
-  cursor: sw-resize;
-}
-.vue-modal-bottomRight {
-  right: 0;
-  bottom: 0;
   cursor: se-resize;
 }
-#vue-modal-triangle::after {
+.vue-modal-resizer::after {
   display: block;
   position: absolute;
   content: '';
@@ -81,7 +23,7 @@
   border-bottom: 10px solid #ddd;
   border-left: 10px solid transparent;
 }
-#vue-modal-triangle.clicked::after {
+.vue-modal-resizer.clicked::after {
   border-bottom: 10px solid #369be9;
 }
 

--- a/docs/Properties.md
+++ b/docs/Properties.md
@@ -12,43 +12,15 @@ Name of the modal, it is required property.
 
 ---
 
-#### `resizable: Boolean`
+#### `resizable: Boolean` 
 
 Enables resizing of the modal.
 
 ---
 
-#### `resizeEdges: Array<String>` `default: ['r', 'br', 'b', 'bl', 'l', 'tl', 't', 'tr']`
-
-Can contain an array with the edges on which you want the modal to be able to resize on.
-| string | corner |
-| ------- | ------------- |
-| r | right |
-| br | bottom right |
-| b | bottom |
-| bl | bottom left |
-| l | left |
-| t | top left |
-| t | top |
-| tr | top right |
-
----
-
-#### `resizeIndicator: Boolean` `default: true`
-
-Enables the resize triangle at the bottom right of a modal when Resizable is enabled.
-
----
-
-#### `centerResize: Boolean` `default: true`
-
-Enables automatic centering of the modal when resizing, if disabled modals will resize and remain in a fixed position similar to how Windows applications are resized.
-
----
-
 #### `adaptive: Boolean`
 
-Enable responsive behavior, modal will try to adapt to the screen size when possible. Properties `maxHeight`, `maxWidth`, `minHeight`, `minWidth` can set the boundaries for the automatic resizing.
+Enable responsive behavior, modal will try to adapt to the screen size when possible. Properties  `maxHeight`, `maxWidth`, `minHeight`, `minWidth` can set the boundaries for the automatic resizing.
 
 ---
 
@@ -106,7 +78,7 @@ Resets position and size before showing
 
 ---
 
-#### `clickToClose: Boolean` `default: true`
+#### `clickToClose: Boolean`  `default: true`
 
 If set to `false`, it will not be possible to close modal by clicking on the background or by pressing Esc key.
 
@@ -130,41 +102,42 @@ List of class that will be applied to the modal window (not overlay, just the bo
 
 ---
 
-#### `styles: String | Array | Object`
+#### `styles: String | Array | Object` 
 
 Style that will be applied to the modal window.
 
+
 ::: warning Note
-To be able to support string definition of styles there are some hacks in place.
+To be able to support string definition of styles there are some hacks in place. 
 
 Vue.js does not allow merging string css definition with an object/array style definition. There are very few cases where you might need to use this property, but if you do - write tests :)
 :::
 
 ---
 
-#### `width: String | Number` `default: 600`
+#### `width: String | Number` `default: 600`     
 
 Width in pixels or percents (50, "50px", "50%").
 
 Supported string values are `<number>%` and `<number>px`
 
 ::: warning Note
-This is not CSS size value, it does not support `em`, `pem`, etc. Plugin requires pixels to recalculate position and size for draggable, resaziable modal.
+This is not CSS size value, it does not support `em`, `pem`, etc. Plugin requires pixels to recalculate position and size for draggable, resaziable modal. 
 If you need to use more value types, please consider contributing to the parser [here](https://github.com/euvl/vue-js-modal/blob/master/src/utils/parser.js).
-:::
+:::   
 
 ---
 
 #### `height: String | Number` `default: 300`
 
-Height in pixels or percents (50, "50px", "50%") or `"auto"`.
-
+Height in pixels or percents (50, "50px", "50%") or `"auto"`.                       
+ 
 Supported string values are `<number>%`, `<number>px` and `auto`. Setting height to `"auto"` makes it automatically change the height when the content size changes (this works well with `scrollable` feature).
 
 ::: warning Note
-This is not CSS size value, it does not support `em`, `pem`, etc. Plugin requires pixels to recalculate position and size for draggable, resaziable modal.
+This is not CSS size value, it does not support `em`, `pem`, etc. Plugin requires pixels to recalculate position and size for draggable, resaziable modal. 
 If you need to use more value types, please consider contributing to the parser [here](https://github.com/euvl/vue-js-modal/blob/master/src/utils/parser.js).
-:::
+:::   
 
 ---
 
@@ -204,8 +177,7 @@ Vertical position in `%`, default is `0.5` (meaning that modal box will be in th
 
 ---
 
-## Example
-
+## Example 
 ```html
 <template>
   <modal name="example"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-js-modal",
-  "version": "2.0.0-rc.6",
+  "version": "2.0.0-rc.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -42,10 +42,6 @@
           :min-height="minHeight"
           :max-width="maxWidth"
           :max-height="maxHeight"
-          :viewport-height="viewportHeight"
-          :viewport-width="viewportWidth"
-          :resize-indicator="resizeIndicator"
-          :resize-edges="resizeEdges"
           @resize="onModalResize"
         />
       </div>
@@ -85,22 +81,6 @@ export default {
     resizable: {
       type: Boolean,
       default: false
-    },
-    resizeEdges: {
-      default: () => ['r', 'br', 'b', 'bl', 'l', 'tl', 't', 'tr'],
-      validator: val =>
-        ['r', 'br', 'b', 'bl', 'l', 'tl', 't', 'tr'].filter(
-          value => val.indexOf(value) !== -1
-        ).length === val.length,
-      type: Array
-    },
-    centerResize: {
-      type: Boolean,
-      default: true
-    },
-    resizeIndicator: {
-      type: Boolean,
-      default: true
     },
     adaptive: {
       type: Boolean,
@@ -566,11 +546,6 @@ export default {
 
       this.modal.heightType = 'px'
       this.modal.height = event.size.height
-      //Handle Shifting
-      if (!this.centerResize) {
-        this.shiftLeft = this.getResizedShiftLeft(event)
-        this.shiftTop = this.getResizedShiftTop(event)
-      }
 
       const { size } = this.modal
 
@@ -582,73 +557,6 @@ export default {
       )
     },
 
-    /**
-     * When centerResize is set to false, the modal has to be shifted so the position of the modal stays fixed.
-     * This method shifts the modal in the x direction.
-     */
-    getResizedShiftLeft(event) {
-      const {
-        viewportHeight,
-        viewportWidth,
-        trueModalWidth,
-        trueModalHeight
-      } = this
-
-      let result = this.shiftLeft
-
-      switch (event.direction) {
-        case 'vue-modal-topRight':
-        case 'vue-modal-bottomRight':
-        case 'vue-modal-right':
-          result = result + 0.5 * event.dimGrowth.width
-          break
-        case 'vue-modal-bottomLeft':
-        case 'vue-modal-topLeft':
-        case 'vue-modal-left':
-          result = result - 0.5 * event.dimGrowth.width
-          break
-        case 'vue-modal-top':
-        case 'vue-modal-bottom':
-          break
-        default:
-          console.error('Could not Find Resize Direction In ShiftLeft')
-      }
-
-      return result
-    },
-    /**
-     * When centerResize is set to false, the modal has to be shifted so the position of the modal stays fixed.
-     * This method shifts the modal in the y direction.
-     */
-    getResizedShiftTop(event) {
-      const {
-        viewportHeight,
-        viewportWidth,
-        trueModalWidth,
-        trueModalHeight
-      } = this
-
-      let result = this.shiftTop
-
-      switch (event.direction) {
-        case 'vue-modal-bottom':
-        case 'vue-modal-bottomRight':
-        case 'vue-modal-bottomLeft':
-          result = result + 0.5 * event.dimGrowth.height
-          break
-        case 'vue-modal-top':
-        case 'vue-modal-topRight':
-        case 'vue-modal-topLeft':
-          result = result - 0.5 * event.dimGrowth.height
-          break
-        case 'vue-modal-left':
-        case 'vue-modal-right':
-          break
-        default:
-          console.error('Could not Find Resize Direction In ShiftTop')
-      }
-      return result
-    },
     open(params) {
       if (this.reset) {
         this.setInitialSize()

--- a/src/components/Resizer.vue
+++ b/src/components/Resizer.vue
@@ -1,14 +1,5 @@
 <template>
-  <div>
-    <div v-if="this.resizeEdges.includes('t')" class="vue-modal-top"></div>
-    <div v-if="this.resizeEdges.includes('b')" class="vue-modal-bottom"></div>
-    <div v-if="this.resizeEdges.includes('l')" class="vue-modal-left"></div>
-    <div v-if="this.resizeEdges.includes('r')" class="vue-modal-right"></div>
-    <div v-if="this.resizeEdges.includes('tr')" class="vue-modal-topRight"></div>
-    <div v-if="this.resizeEdges.includes('tl')" class="vue-modal-topLeft"></div>
-    <div v-if="this.resizeEdges.includes('br')" :id="getID" :class="className"></div>
-    <div v-if="this.resizeEdges.includes('bl')" class="vue-modal-bottomLeft"></div>
-  </div>
+  <div :class="className"></div>
 </template>
 <script>
 import { inRange, windowWidthWithoutScrollbar } from '../utils'
@@ -31,31 +22,12 @@ export default {
     maxHeight: {
       type: Number,
       default: Number.MAX_SAFE_INTEGER
-    },
-    viewportWidth: {
-      type: Number,
-      required: true
-    },
-    viewportHeight: {
-      type: Number,
-      required: true
-    },
-    resizeIndicator: {
-      type: Boolean,
-      default: true
-    },
-    resizeEdges: {
-      type: Array,
-      required: true
     }
   },
   data() {
     return {
       clicked: false,
-      targetClass: '',
-      size: {},
-      initialX: 0,
-      initialY: 0
+      size: {}
     }
   },
   mounted() {
@@ -64,19 +36,12 @@ export default {
   computed: {
     className() {
       const { clicked } = this
-      return ['vue-modal-bottomRight', { clicked }]
-    },
-    getID() {
-      if (this.resizeIndicator) return 'vue-modal-triangle'
-      else return ''
+      return ['vue-modal-resizer', { clicked }]
     }
   },
   methods: {
     start(event) {
-      this.targetClass = event.target.className
       this.clicked = true
-      this.initialX = event.clientX
-      this.initialY = event.clientY
 
       window.addEventListener('mousemove', this.mousemove, false)
       window.addEventListener('mouseup', this.stop, false)
@@ -87,10 +52,6 @@ export default {
 
     stop() {
       this.clicked = false
-      this.clicked = false
-      this.targetClass = ''
-      this.initialX = 0
-      this.initialY = 0
 
       window.removeEventListener('mousemove', this.mousemove, false)
       window.removeEventListener('mouseup', this.stop, false)
@@ -104,79 +65,27 @@ export default {
     mousemove(event) {
       this.resize(event)
     },
+
     resize(event) {
       var el = this.$el.parentElement
 
-      var width = event.clientX
-      var height = event.clientY
-      var styleWidth = parseInt(el.style.width.replace('px', ''))
-      var styleHeight = parseInt(el.style.height.replace('px', ''))
-
-      //Block Resize if mouse outside visable space.
-      if (event.clientX > this.viewportWidth || event.clientX < 0) return
-      if (event.clientY > this.viewportHeight || event.clientY < 0) return
-
-      //Calcualte new  Widht/Height based on direction
       if (el) {
-        switch (this.targetClass) {
-          case 'vue-modal-right':
-            width = width - el.offsetLeft
-            height = styleHeight
-            break
-          case 'vue-modal-left':
-            height = styleHeight
-            width = styleWidth + (this.initialX - event.clientX)
-            break
-          case 'vue-modal-top':
-            width = styleWidth
-            height = styleHeight + (this.initialY - event.clientY)
-            break
-          case 'vue-modal-bottom':
-            width = styleWidth
-            height = height - el.offsetTop
-            break
-          case 'vue-modal-bottomRight':
-            width = width - el.offsetLeft
-            height = height - el.offsetTop
-            break
-          case 'vue-modal-topRight':
-            width = width - el.offsetLeft
-            height = styleHeight + (this.initialY - event.clientY)
-            break
-          case 'vue-modal-bottomLeft':
-            width = styleWidth + (this.initialX - event.clientX)
-            height = height - el.offsetTop
-            break
-          case 'vue-modal-topLeft':
-            width = styleWidth + (this.initialX - event.clientX)
-            height = styleHeight + (this.initialY - event.clientY)
-            break
-          default:
-            console.error('Incorrrect/no resize direction.')
-        }
+        var width = event.clientX - el.offsetLeft
+        var height = event.clientY - el.offsetTop
 
         const maxWidth = Math.min(windowWidthWithoutScrollbar(), this.maxWidth)
         const maxHeight = Math.min(window.innerHeight, this.maxHeight)
+
         width = inRange(this.minWidth, maxWidth, width)
         height = inRange(this.minHeight, maxHeight, height)
-        this.initialX = event.clientX
-        this.initialY = event.clientY
 
         this.size = { width, height }
-
-        //Calculate growth in each dimension to be used when shifting the modal.
-        const dimGrowth = {
-          width: width - styleWidth,
-          height: height - styleHeight
-        }
-
         el.style.width = width + 'px'
         el.style.height = height + 'px'
+
         this.$emit('resize', {
           element: el,
-          size: this.size,
-          direction: this.targetClass,
-          dimGrowth: dimGrowth
+          size: this.size
         })
       }
     }
@@ -184,82 +93,20 @@ export default {
 }
 </script>
 <style>
-.vue-modal-top,
-.vue-modal-bottom,
-.vue-modal-left,
-.vue-modal-right,
-.vue-modal-topRight,
-.vue-modal-topLeft,
-.vue-modal-bottomLeft,
-.vue-modal-bottomRight {
+.vue-modal-resizer {
   display: block;
   overflow: hidden;
   position: absolute;
-  background: transparent;
+  width: 12px;
+  height: 12px;
+  right: 0;
+  bottom: 0;
   z-index: 9999999;
-}
-.vue-modal-topRight,
-.vue-modal-topLeft,
-.vue-modal-bottomLeft,
-.vue-modal-bottomRight {
-  width: 12px;
-  height: 12px;
-}
-.vue-modal-top {
-  right: 12;
-  top: 0;
-  width: 100%;
-  height: 12px;
-  cursor: n-resize;
-}
-
-.vue-modal-bottom {
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  height: 12px;
-  cursor: s-resize;
-}
-
-.vue-modal-left {
-  left: 0;
-  top: 0;
-  width: 12px;
-  height: 100%;
-  cursor: w-resize;
-}
-
-.vue-modal-right {
-  right: 0;
-  top: 0;
-  width: 12px;
-  height: 100%;
-  cursor: e-resize;
-}
-
-.vue-modal-topRight {
-  right: 0;
-  top: 0;
   background: transparent;
-  cursor: ne-resize;
-}
-.vue-modal-topLeft {
-  left: 0;
-  top: 0;
-  cursor: nw-resize;
-}
-.vue-modal-bottomLeft {
-  left: 0;
-  bottom: 0;
-  cursor: sw-resize;
-}
-.vue-modal-bottomRight {
-  right: 0;
-  bottom: 0;
   cursor: se-resize;
 }
 
-#vue-modal-triangle::after {
+.vue-modal-resizer::after {
   display: block;
   position: absolute;
   content: '';
@@ -272,7 +119,7 @@ export default {
   border-left: 10px solid transparent;
 }
 
-#vue-modal-triangle.clicked::after {
+.vue-modal-resizer.clicked::after {
   border-bottom: 10px solid #369be9;
 }
 </style>


### PR DESCRIPTION
Reverts euvl/vue-js-modal#610

Hey @Jahb, @Mirijam1 there seem to be some regressions happening with the latest change to resizer. Particularly, resizing stops working when the mouse pointer gets outside of the screen (which is a requirement for not-full-screen windows and desktop apps). 


I've created a revert PR but then if you want to look on what went wrong before I merge it I am happy to close it.

Gif of the correct behaviour (see currently published version):

![Kapture 2020-09-03 at 06 57 56](https://user-images.githubusercontent.com/1577802/92076656-da42e480-edb2-11ea-95d9-e84addbef907.gif)

