### PR TITLE
Fix SSR docs: Inject modal reference for Nuxt

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -51,11 +51,9 @@ import 'vue-js-modal/dist/styles.css'
 
 Vue.use(VModal, { ... })
 
-/*
 export default function(_, inject) {
-  inject('modal', VModal)
+  inject('modal', Vue.prototype.$modal)
 }
-*/
 ```
 
 ::: tip Extracted CSS


### PR DESCRIPTION
Inject model reference instead of VModel which resolves to function which installs the plugin. 

Explained in detail here: https://github.com/euvl/vue-js-modal/issues/561#issuecomment-751418246