### PR TITLE
feat: add missing TypeScript exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18037,6 +18037,12 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "dev": true
+    },
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   "browserslist": "> 0.25%, not dead",
   "devDependencies": {
     "@babel/core": "^7.2.0",
-    "@babel/preset-env": "^7.2.0",
     "@babel/plugin-proposal-optional-chaining": "^7.10.3",
+    "@babel/preset-env": "^7.2.0",
     "@vue/eslint-config-prettier": "^6.0.0",
     "@vue/test-utils": "1.0.0-beta.31",
     "babel-jest": "^23.6.0",
@@ -64,6 +64,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "sass-loader": "^7.1.0",
     "ts-loader": "^6.2.2",
+    "typescript": "^4.3.2",
     "uglifyjs-webpack-plugin": "^2.2.0",
     "vue": "2.6.11",
     "vue-hot-reload-api": "^2.0.8",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,9 @@
-import Vue, { PluginObject, ComponentOptions, AsyncComponent } from 'vue'
+import Vue, { PluginObject, ComponentOptions, AsyncComponent, VueConstructor } from 'vue'
+
+export declare const version: string
+
+export declare const Modal: VueConstructor
+export declare const Dialog: VueConstructor
 
 export declare interface VueJSModalOptions {
   componentName?: string

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -1,5 +1,11 @@
-import Vue from "vue";
-import VueJSModal, { VueJSModalOptions } from "../index";
+import Vue, { CreateElement } from "vue";
+import VueJSModal, { VueJSModalOptions, Modal, Dialog, version } from "../index";
+
+const versionTest: string = version
+
+const createElement: CreateElement = undefined as unknown as CreateElement
+createElement(Modal)
+createElement(Dialog)
 
 Vue.use(VueJSModal);
 Vue.use<VueJSModalOptions>(VueJSModal, {


### PR DESCRIPTION
- Add `typescript` dependency so we can run `tsc`
- Add `Modal` export type
- Add `Dialog` export type
- Add `version` export type