### PR TITLE
Flexable <Dialog/> component name

### DIFF
--- a/src/Plugin.js
+++ b/src/Plugin.js
@@ -40,7 +40,8 @@ const Plugin = {
      * Registration of <Dialog/> component
      */
     if (options.dialog) {
-      Vue.component('VDialog', Dialog)
+      const componentName = options.dialogComponentName || 'VDialog';
+      Vue.component(componentName, Dialog);
     }
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,6 +3,7 @@ import Vue, { PluginObject, ComponentOptions, AsyncComponent } from 'vue'
 export declare interface VueJSModalOptions {
   componentName?: string
   dialog?: boolean
+  dialogComponentName?: string
   dynamicDefaults?: object
 }
 


### PR DESCRIPTION
`v-dialog` can conflict with other libs such as Vuetify. To manage it I suggest to give an opportunity to set another dialog component name by `dialogComponentName` option.