### PR TITLE
Added support for slots in dynamic modal - Fixes #400

### DIFF
--- a/src/PluginCore.js
+++ b/src/PluginCore.js
@@ -17,6 +17,7 @@ const PluginCore = (Vue, options = {}) => {
   const showDynamicModal = (
     component,
     componentProps,
+    componentSlots,
     modalProps = {},
     modalEvents
   ) => {
@@ -26,6 +27,7 @@ const PluginCore = (Vue, options = {}) => {
     container?.add(
       component,
       componentProps,
+      componentSlots,
       { ...defaults, ...modalProps },
       modalEvents
     )

--- a/src/components/ModalsContainer.vue
+++ b/src/components/ModalsContainer.vue
@@ -12,12 +12,17 @@
         v-bind="modal.componentAttrs"
         v-on="$listeners"
         @close="$modal.hide(modal.modalAttrs.name, $event)"
-      />
+      >
+        <template v-for="(slot, key) in modal.componentSlots" #[key]="scope">
+          <VNode :node="slot" :key="key" :scope="scope" />
+        </template>
+      </component>
     </modal>
   </div>
 </template>
 <script>
 import { generateId } from '../utils'
+import VNode from './VNode.vue'
 
 const PREFIX = 'dynamic_modal_'
 
@@ -26,6 +31,9 @@ export default {
     return {
       modals: []
     }
+  },
+  components: {
+    VNode
   },
   created() {
     /**
@@ -39,7 +47,13 @@ export default {
     })
   },
   methods: {
-    add(component, componentAttrs = {}, modalAttrs = {}, modalListeners = {}) {
+    add(
+      component,
+      componentAttrs = {},
+      componentSlots = {},
+      modalAttrs = {},
+      modalListeners = {}
+    ) {
       const id = generateId()
       const name = modalAttrs.name || PREFIX + id
 
@@ -48,7 +62,8 @@ export default {
         modalAttrs: { ...modalAttrs, name },
         modalListeners,
         component,
-        componentAttrs
+        componentAttrs,
+        componentSlots
       })
 
       this.$nextTick(() => {

--- a/src/components/VNode.vue
+++ b/src/components/VNode.vue
@@ -1,0 +1,22 @@
+<script>
+import { isFunction } from '../utils/types'
+
+export default {
+  name: 'VNode',
+  props: {
+    node: {
+      type: [Object, Function],
+      required: true
+    },
+    scope: {
+      type: Object,
+      default: () => ({})
+    }
+  },
+  render() {
+    if (isFunction(this.node)) return this.node(this.scope)
+
+    return this.node
+  }
+}
+</script>

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -9,3 +9,7 @@ export const isObject = value => {
 export const isFn = value => {
   return typeof value === 'function'
 }
+
+export const isFunction = value => {
+  return typeof value === 'function'
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,6 +14,7 @@ declare interface VModal {
   show(
     component: typeof Vue | ComponentOptions<Vue> | AsyncComponent,
     componentProps?: object,
+    componentSlots?: object,
     modalProps?: object,
     modalEvents?: object
   ): void


### PR DESCRIPTION
Made it possible to pass slots to dynamic modals.

For example, we have a modal component - `ExampleModal`

If we want to call it dynamically, we'll do something like:

```
this.$modal.show(ExampleModal)
```

But if ExampleModal has slots, for example:
```
<template>
  <div>
    <slot />
  </div>
</template>
```

We can pass slots like this:

```
this.$modal.show(ExampleModal, {}, {
  default: this.$createElement('span', 'message')
})
```

If we have scoped slots, for example:
```
<template>
  <div>
    <slot name="test" :number="42" />
  </div>
</template>
```

We can pass them like:

```
this.$modal.show(ExampleModal, {}, {
 test: scope => this.$createElement('span', `Number: ${scope.number}`)
})
```