### PR TITLE
Parent component now sets the keys used to close the modal

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -95,6 +95,10 @@ export default {
       type: Boolean,
       default: true
     },
+    keysToClose: {
+      type: [String, Array],
+      default: ["Escape"]
+    },
     classes: {
       type: [String, Array],
       default: 'v--modal'
@@ -178,6 +182,8 @@ export default {
         height: 0
       },
 
+      closeKeyDown: false, // Whether or not a key used for closing the modal is currently pressed down
+
       mutationObserver: null
     }
   },
@@ -232,20 +238,18 @@ export default {
       }
     }
 
-    if (this.clickToClose) {
-      window.addEventListener('keyup', this.handleEscapeKeyUp)
-    }
+    window.addEventListener('keyup', this.onKeyUpForClose)
+    window.addEventListener('keydown', this.onKeyDownForClose)
   },
   /**
    * Removes global listeners
    */
   beforeDestroy () {
     Modal.event.$off('toggle', this.handleToggleEvent)
+    
     window.removeEventListener('resize', this.handleWindowResize)
-
-    if (this.clickToClose) {
-      window.removeEventListener('keyup', this.handleEscapeKeyUp)
-    }
+    window.removeEventListener('keyup', this.onKeyUpForClose)
+    window.removeEventListener('keydown', this.onKeyDownForClose)
     /**
      * Removes blocked scroll
      */
@@ -413,8 +417,15 @@ export default {
       modal.heightType = height.type
     },
 
-    handleEscapeKeyUp (event) {
-      if (event.which === 27 && this.visible) {
+    onKeyDownForClose(event) {
+      if (this.keysToClose.includes(event.key) && this.visible) {
+        this.closeKeyDown = true
+      }
+    },
+
+    onKeyUpForClose(event) {
+      if (this.keysToClose.includes(event.key) && this.visible && this.closeKeyDown) {
+        this.closeKeyDown = false
         this.$modal.hide(this.name)
       }
     },


### PR DESCRIPTION
The parent component provides the keysToClose prop with an array of strings specifying which keys should be able to close the modal (Example: ["Escape", "Enter", " "])

I found an edge-case where if the dialog is opened by the parent component by a certain key and the modal is configured to close with that same key, it will immediately close after opening. For example, the parent decides to open the modal when the enter key is pressed down. If the modal is configured to close with the enter key, it will immediately close once that same key that was used to open it is released.
To fix this, I added a boolean to track if a key that is used to close the modal has been pressed down. This boolean is then checked before closing the modal from a key press. This makes it so the modal will not close unless the key configured to close it is pressed down and then released.

One controversial change worth mentioning is backwards compatibility. Any previous usages of this modal that had clickToClose set to false will now close when the Esc key is pressed (unless the parent is changed to pass an empty array to the keysToClose prop).
My justification for this change is to allow for the capability for the dialog to not be closable by clicking, yet still be closable by the keys specified in the parent.
If we wish to have this commit perfectly backwards compatible, adding back the "if clickToClose" statement surrounding the add/remove listener lines will do the trick, but it won't be possible to have the dialog not closable by clicking, yet closable by pressing a key.

One last point to mention is that if we wish for Dialog.vue to also allow the parent to set the keys to close it, it will need a simple change to take the keysToClose prop in-and-out.