### PR TITLE
Fix SHIFT + TAB issue on last element in focusTrap

### DIFF
--- a/src/utils/focusTrap.js
+++ b/src/utils/focusTrap.js
@@ -65,7 +65,7 @@ class FocusTrap {
     }
 
     // TAB
-    if (isNothingFocused() || isFocused(this.lastElement())) {
+    if (isNothingFocused() || (!event.shiftKey && isFocused(this.lastElement()))) {
       this.firstElement().focus()
       event.preventDefault()
       return


### PR DESCRIPTION
This will prevent a jump from the last to the first element when you press SHIFT + TAB on the last element, which isn't the first element.

## Issue
Given you have three focusable elements: A, B, C.

### Order on TAB (correct)
A > B > C > A > B > C > etc.

### Order on SHIFT + TAB (incorrect)
A > C > A > C > A > etc.