### PR TITLE
Forward attributes to actual modal

### DIFF
--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -34,6 +34,7 @@
         :style="modalStyle"
         role="dialog"
         aria-modal="true"
+        v-bind="$attrs"
       >
         <slot />
         <resizer
@@ -77,6 +78,7 @@ const TransitionState = {
 
 export default {
   name: 'VueJsModal',
+  inheritAttrs: false,
   props: {
     name: {
       required: true,


### PR DESCRIPTION
An `aria-label` or `aria-labelledby` are [required](https://w3c.github.io/aria-practices/#dialog_roles_states_props) for modals, but currently there is no way to set these attributes. This PR allows you to set extra attributes (e.g. aria properties) on the modal element.

See: https://v2.vuejs.org/v2/guide/components-props.html#Disabling-Attribute-Inheritance