### PR TITLE
fix: click-event in draggable modal not triggered on mobile device

### DIFF
--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -55,7 +55,7 @@
 <script>
 import Resizer from './Resizer.vue'
 import {
-  isInput,
+  isInputOrClickable,
   inRange,
   getTouchEvent,
   blurActiveElement,
@@ -190,7 +190,11 @@ export default {
       validator(value) {
         return value >= 0 && value <= 1
       }
-    }
+    },
+    undraggableElement: {
+      type: [Array],
+      default: () => []
+    },
   },
   components: {
     Resizer
@@ -770,7 +774,7 @@ export default {
         const handleDraggableMousedown = event => {
           let target = event.target
 
-          if (isInput(target)) {
+          if (isInputOrClickable(target, this.undraggableElement)) {
             return
           }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,6 @@
 export * from './numbers'
 
-const INPUT_NODE_NAMES = ['INPUT', 'TEXTAREA', 'SELECT']
+const INPUT_OR_CLICKABLE_NODE_NAMES = ['INPUT', 'TEXTAREA', 'SELECT', "BUTTON", "SPAN"]
 
 export const generateId = ((index = 0) => () => (index++).toString())()
 /**
@@ -59,8 +59,8 @@ export const stringStylesToObject = styles => {
   }, {})
 }
 
-export const isInput = element => {
-  return element && INPUT_NODE_NAMES.indexOf(element.nodeName) !== -1
+export const isInputOrClickable = (element, dynamicElement = []) => {
+  return element && (INPUT_OR_CLICKABLE_NODE_NAMES.indexOf(element.nodeName) !== -1 || dynamicElement.indexOf(element.nodeName) !== -1)
 }
 
 export const getTouchEvent = event => {


### PR DESCRIPTION
Hello, Yev Vlasenko @euvl ~
At first, thank you for your good plugin~

In the process of using the dragable model, I found that the click-event of the mobile device would has some problems, so I made the following correction.

1. add a "undraggableElement" prop params for configuring undraggable elements, which is more convenient to use
2. modified the "isInput" method and the INPUT_NODE_NAMES constants to better adapt to the the mobile`s click-event

The above fix can solve the problem on mobile~

Limited ability, make it better~